### PR TITLE
Fix code portability when looking for Dot

### DIFF
--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -12,7 +12,6 @@ import os.path
 import pickle
 import pstats
 import shutil
-import subprocess
 import traceback
 from collections.abc import Iterator
 from typing import Any, Callable, IO, Optional, Union

--- a/torch/_inductor/debug.py
+++ b/torch/_inductor/debug.py
@@ -53,11 +53,7 @@ GRAPHVIZ_COMMAND_SCALABLE = ["dot", "-Gnslimit=2", "-Gnslimit1=2", "-Gmaxiter=50
 
 @functools.lru_cache(None)
 def has_dot() -> bool:
-    try:
-        subprocess.check_output(["which", "dot"], stderr=subprocess.PIPE)
-        return True
-    except subprocess.SubprocessError:
-        return False
+    return shutil.which("dot") is not None
 
 
 def draw_buffers(


### PR DESCRIPTION
When trying to plot a trace graph, Inductor checks if "dot" is installed. Currently, the code runs a "which dot" command.

By default, Windows doesn't have the "which" command. This patch replaces it with the more portable alternative.